### PR TITLE
Feature #11 added, Config_TLS.txt file now hold tls enabled configs

### DIFF
--- a/Files/app.py
+++ b/Files/app.py
@@ -101,7 +101,7 @@ def main():
     filename1 = os.path.join(output_folder, f'All_Configs_base64_Sub.txt')
     if os.path.exists(filename):
         os.remove(filename)
-    elif os.path.exists(filename1):
+    if os.path.exists(filename1):
         os.remove(filename1)
     for i in range(20):
         filename = os.path.join(output_folder, f'Config list{i}.txt')
@@ -110,7 +110,11 @@ def main():
         filename1 = os.path.join(base64_folder, f'Config list{i}_base64.txt')
         if os.path.exists(filename1):
             os.remove(filename1)
-    
+
+    # Remove TLS configs file
+    filename = os.path.join(output_folder, f'Config_TLS.txt')
+    if os.path.exists(filename):
+        os.remove(filename)
 
     # Write merged configs to output file
     output_file = os.path.join(output_folder, 'All_Configs_Sub.txt')
@@ -150,7 +154,13 @@ def main():
 
         with open(output_filename, 'w') as output_file:
             output_file.write(encoded_config)
-    
+
+    # Take all tls enabled configs and save them to Configs_TLS.txt
+    tls_file = os.path.join(output_folder, f"Configs_TLS.txt")
+    with open(tls_file, "w") as f:
+        for line in lines:
+            if "security=tls" in line:
+                f.write(line)
 
     
 if __name__ == "__main__":

--- a/Files/app.py
+++ b/Files/app.py
@@ -162,6 +162,16 @@ def main():
             if "security=tls" in line:
                 f.write(line)
 
+    # Take all tls enabled configs from tls_file, encode and save them to Configs_TLS_base64.txt
+    tls_encoded_file = os.path.join(output_folder, f'Config_TLS_base64.txt')
+    with open(tls_file, 'r') as input_file:
+        tls_config_data = input_file.read()
+    
+    encoded_tls_config = base64.b64encode(tls_config_data.encode()).decode()
+
+    with open(tls_encoded_file, 'w') as output_file:
+        output_file.write(encoded_tls_config)
+
     
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Issue number #11 requested a TLS enabled only config file, so i added a statement that uses the already created lines variable and check wether it contains "security=tls" in the string, if so that line will get written to the Config_TLS.txt file, i tried to not touch other parts of the code but i did notice something, line 104: 
###
    elif os.path.exists(filename1):
        os.remove(filename1)
###
if the idea is to remove the files, the base 64 file should also be removed, but the elif statement checks if All_Config_Sub.txt exists, if so the code removes that file meaning the base64 file is never removed, i tested the code and it seemed to work tho i had some problem with unicode characters, they were being replaced with <undefined> so i had to run the code with python -X utf8 app.py, not a conceren if the code works on github actions. Please test for yourself and merge the request.